### PR TITLE
Add kvdb_sqlite build tag to enable SQLite backend support

### DIFF
--- a/linuxamd64.Dockerfile
+++ b/linuxamd64.Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /go/src/github.com/lightningnetwork/lnd
 COPY . .
 
 RUN make \
-&&  make install tags="signrpc walletrpc chainrpc invoicesrpc routerrpc watchtowerrpc"
+&&  make install tags="signrpc walletrpc chainrpc invoicesrpc routerrpc watchtowerrpc kvdb_sqlite"
 
 
 # Build loop binary

--- a/linuxarm32v7.Dockerfile
+++ b/linuxarm32v7.Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /go/src/github.com/lightningnetwork/lnd
 COPY . .
 
 RUN make \
-&&  make install tags="signrpc walletrpc chainrpc invoicesrpc routerrpc watchtowerrpc"
+&&  make install tags="signrpc walletrpc chainrpc invoicesrpc routerrpc watchtowerrpc kvdb_sqlite"
 
 # Build loop binary
 RUN git clone --depth 1 --branch v0.31.2-beta https://github.com/lightninglabs/loop.git /go/src/github.com/lightninglabs/loop

--- a/linuxarm64v8.Dockerfile
+++ b/linuxarm64v8.Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /go/src/github.com/lightningnetwork/lnd
 COPY . .
 
 RUN make -d \
-&&  make install tags="signrpc walletrpc chainrpc invoicesrpc routerrpc watchtowerrpc"
+&&  make install tags="signrpc walletrpc chainrpc invoicesrpc routerrpc watchtowerrpc kvdb_sqlite"
 
 # Build loop binary
 RUN git clone --depth 1 --branch v0.31.2-beta https://github.com/lightninglabs/loop.git /go/src/github.com/lightninglabs/loop


### PR DESCRIPTION
**Description:**

This PR adds the `kvdb_sqlite` build tag to the `make install` command across all three architecture Dockerfiles (`linuxamd64`, `linuxarm64v8`, `linuxarm32v7`).

**Problem**

The current BTCPay Server LND image (v0.19.3-beta) is not compiled with SQLite support. Users who attempt to migrate from bbolt to SQLite using `lndinit migrate-db` find that the migration completes successfully on all five databases (channeldb, macaroondb, decayedlogdb, walletdb, neutrinodb), but LND fails on startup with:

```
error opening sqlite graph DB: unknown database type
```

This is because the `kvdb_sqlite` build tag is missing from the Dockerfiles.

Additionally, `lndinit` writes internal tombstones into the original bbolt files during migration, so users who hit this error must restore from backup to revert. This makes the failure particularly disruptive.

**Fix**

One-line change per Dockerfile, adding `kvdb_sqlite` to the existing build tags:

```
make install tags="signrpc walletrpc chainrpc invoicesrpc routerrpc watchtowerrpc kvdb_sqlite"
```

**Why this matters**

SQLite offers meaningful performance improvements over bbolt for resource-constrained environments (Raspberry Pi, low-RAM VPS) where bbolt's lock contention and compaction overhead can cause issues. SQLite's WAL (Write-Ahead Logging) mode also provides significantly better crash recovery compared to bbolt, which is prone to database corruption on unclean shutdowns. I personally lost a 2-year-old Lightning channel due to bbolt corruption after a power outage, something SQLite's crash recovery model is specifically designed to handle gracefully.
Upstream LND has supported SQLite since v0.16 and the migration tooling (lndinit migrate-db) works correctly. The only missing piece is the build tag.

Fixes/Related to: btcpayserver/btcpayserver-docker#1046

cc @rockstardev